### PR TITLE
Acb fractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This plugin (currently) converts:
 - `<-` to `←` (customizable)
 - `<<` to `«`
 - `>>` to `»`
+- `1/2` to `½`
+- `1/4` to `¼`
+- `3/4` to `¾`
 - Two dashes (`--`) to – - en-dash
 - En-dash + dash (`–-`) to — - em-dash
 - Em-dash + dash (`—-`) to `---` - three dashes

--- a/inputRules.ts
+++ b/inputRules.ts
@@ -296,6 +296,50 @@ export const leftGuillemet: InputRule = {
   },
 };
 
+export const vulgarFractionHalf: InputRule = {
+  matchTrigger: "2",
+  matchRegExp: /1\/2$/,
+  performUpdate: (instance, delta, settings) => {
+    delta.update({ line: delta.from.line, ch: delta.from.ch - 1 }, delta.to, [
+      "½",
+    ]);
+  },
+  performRevert: (instance, delta, settings) => {
+    if (instance.getRange(delta.from, delta.to) === "½") {
+      delta.update(delta.from, delta.to, ["1/2"]);
+    }
+  },
+};
+
+export const vulgarFactionOneQuarter: InputRule = {
+  matchTrigger: "4",
+  matchRegExp: /1\/4$/,
+  performUpdate: (instance, delta, settings) => {
+    delta.update({ line: delta.from.line, ch: delta.from.ch - 1 }, delta.to, [
+      "¼",
+    ]);
+  },
+  performRevert: (instance, delta, settings) => {
+    if (instance.getRange(delta.from, delta.to) === "¼") {
+      delta.update(delta.from, delta.to, ["1/4"]);
+    }
+  },
+};
+
+export const vulgarFractionThreeQuarters: InputRule = {
+  matchTrigger: "4",
+  matchRegExp: /3\/4$/,
+  performUpdate: (instance, delta, settings) => {
+    delta.update({ line: delta.from.line, ch: delta.from.ch - 1 }, delta.to, [
+      "¾",
+    ]);
+  },
+  performRevert: (instance, delta, settings) => {
+    if (instance.getRange(delta.from, delta.to) === "¾") {
+      delta.update(delta.from, delta.to, ["3/4"]);
+    }
+  },
+};
 export const dashRules = [enDash, emDash, trippleDash];
 export const ellipsisRules = [ellipsis];
 export const smartQuoteRules = [
@@ -315,3 +359,10 @@ export const comparisonRules = [
 ];
 export const arrowRules = [leftArrow, rightArrow];
 export const guillemetRules = [leftGuillemet, rightGuillemet];
+
+export const fractionRules = [
+  vulgarFractionHalf,
+  vulgarFactionOneQuarter,
+  vulgarFractionThreeQuarters,
+];
+

--- a/inputRules.ts
+++ b/inputRules.ts
@@ -300,7 +300,7 @@ export const vulgarFractionHalf: InputRule = {
   matchTrigger: "2",
   matchRegExp: /1\/2$/,
   performUpdate: (instance, delta, settings) => {
-    delta.update({ line: delta.from.line, ch: delta.from.ch - 1 }, delta.to, [
+    delta.update({ line: delta.from.line, ch: delta.from.ch - 2 }, delta.to, [
       "½",
     ]);
   },
@@ -315,7 +315,7 @@ export const vulgarFactionOneQuarter: InputRule = {
   matchTrigger: "4",
   matchRegExp: /1\/4$/,
   performUpdate: (instance, delta, settings) => {
-    delta.update({ line: delta.from.line, ch: delta.from.ch - 1 }, delta.to, [
+    delta.update({ line: delta.from.line, ch: delta.from.ch - 2 }, delta.to, [
       "¼",
     ]);
   },
@@ -330,7 +330,7 @@ export const vulgarFractionThreeQuarters: InputRule = {
   matchTrigger: "4",
   matchRegExp: /3\/4$/,
   performUpdate: (instance, delta, settings) => {
-    delta.update({ line: delta.from.line, ch: delta.from.ch - 1 }, delta.to, [
+    delta.update({ line: delta.from.line, ch: delta.from.ch - 2 }, delta.to, [
       "¾",
     ]);
   },

--- a/main.ts
+++ b/main.ts
@@ -397,6 +397,18 @@ class SmartTypographySettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           });
       });
+
+      new Setting(containerEl)
+      .setName("Fractions")
+      .setDesc("1/2, 1/4, 3/4 will be converted to ½,¼,¾")
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.comparisons)
+          .onChange(async (value) => {
+            this.plugin.settings.comparisons = value;
+            await this.plugin.saveSettings();
+          });
+      });
   }
 }
 

--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,7 @@ const DEFAULT_SETTINGS: SmartTypographySettings = {
   arrows: true,
   guillemets: false,
   comparisons: true,
+  fractions: true,
 
   openSingle: "‘",
   closeSingle: "’",
@@ -66,6 +67,9 @@ export default class SmartTypography extends Plugin {
     }
     if (this.settings.comparisons) {
       this.inputRules.push(...comparisonRules);
+    }
+    if (this.settings.fractions) {
+      this.inputRules.push(...fractionRules);
     }
   }
 
@@ -405,7 +409,7 @@ class SmartTypographySettingTab extends PluginSettingTab {
         toggle
           .setValue(this.plugin.settings.comparisons)
           .onChange(async (value) => {
-            this.plugin.settings.comparisons = value;
+            this.plugin.settings.fractions = value;
             await this.plugin.saveSettings();
           });
       });

--- a/main.ts
+++ b/main.ts
@@ -6,6 +6,7 @@ import {
   smartQuoteRules,
   guillemetRules,
   comparisonRules,
+  fractionRules,
 } from "inputRules";
 import { App, Plugin, PluginSettingTab, Setting } from "obsidian";
 import { SmartTypographySettings } from "types";
@@ -30,6 +31,10 @@ const DEFAULT_SETTINGS: SmartTypographySettings = {
   lessThanOrEqualTo: "≤",
   greaterThanOrEqualTo: "≥",
   notEqualTo: "≠",
+
+  vulgarFractionOneQuarter: "¼",
+  vulgarFractionHalf: "½",
+  vulgarFractionThreeQuarters: "¾"
 };
 
 export default class SmartTypography extends Plugin {

--- a/main.ts
+++ b/main.ts
@@ -38,6 +38,8 @@ const DEFAULT_SETTINGS: SmartTypographySettings = {
   vulgarFractionThreeQuarters: "¾"
 };
 
+/* adding comment to stimulate recompilation */
+
 export default class SmartTypography extends Plugin {
   settings: SmartTypographySettings;
   inputRules: InputRule[];

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
 	"id": "obsidian-smart-typography",
 	"name": "Smart Typography",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"minAppVersion": "0.11.13",
-	"description": "Converts quotes to curly quotes, dashes to em dashes, and periods to ellipses",
+	"description": "Converts quotes to curly quotes, dashes to em dashes, and periods to ellipses; also does some fractions",
 	"author": "mgmeyers",
 	"authorUrl": "https://github.com/mgmeyers/obsidian-smart-typography",
 	"isDesktopOnly": true

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "obsidian-sample-plugin",
+  "name": "obsidian-smart-typography",
   "version": "0.12.0",
-  "description": "This is a sample plugin for Obsidian (https://obsidian.md)",
+  "description": "This is a smart typography plugin for Obsidian (https://obsidian.md)",
   "main": "main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
     "build": "rollup --config rollup.config.js --environment BUILD:production"
   },
   "keywords": [],
-  "author": "",
+  "author": "Matthew Myers",
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-commonjs": "^18.0.0",

--- a/types.ts
+++ b/types.ts
@@ -15,4 +15,7 @@ export interface SmartTypographySettings {
   lessThanOrEqualTo: string;
   greaterThanOrEqualTo: string;
   notEqualTo: string;
+  vulgarFractionOneQuarter: string;
+  vulgarFractionHalf: string;
+  vulgarFractionThreeQuarters: string;
 }

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,5 @@
 export interface SmartTypographySettings {
+  fractions: boolean;
   curlyQuotes: boolean;
   emDash: boolean;
   ellipsis: boolean;


### PR DESCRIPTION
I have added a little fix that makes some fractions into their proper glyphs — 
`1/4` become `¼` ; `1/2` becomes `½`; and `3/4` is turned into `¾`.
This is mainly to tidy up the recipes I put into Obsidian but other people may find it useful. 

I get  a bunch of linting errors when I run `yarn dev` (see below) but since I don't understand them, they apply on the main branch too, and they don't seem to stop anything working, I have ignored them.

```
[{
	"resource": "/c:/Users/Andrew/Github projects/obsidian-smart-typography/main.js",
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "W097",
	"severity": 4,
	"message": "Use the function form of \"use strict\". (W097)",
	"source": "jshint",
	"startLineNumber": 6,
	"startColumn": 1,
	"endLineNumber": 6,
	"endColumn": 1
},{
	"resource": "/c:/Users/Andrew/Github projects/obsidian-smart-typography/main.js",
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "W117",
	"severity": 4,
	"message": "'require' is not defined. (W117)",
	"source": "jshint",
	"startLineNumber": 8,
	"startColumn": 16,
	"endLineNumber": 8,
	"endColumn": 16
},{
	"resource": "/c:/Users/Andrew/Github projects/obsidian-smart-typography/main.js",
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "W056",
	"severity": 4,
	"message": "Bad constructor. (W056)",
	"source": "jshint",
	"startLineNumber": 27,
	"startColumn": 35,
	"endLineNumber": 27,
	"endColumn": 35
},{
	"resource": "/c:/Users/Andrew/Github projects/obsidian-smart-typography/main.js",
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "W030",
	"severity": 4,
	"message": "Expected an assignment or function call and instead saw an expression. (W030)",
	"source": "jshint",
	"startLineNumber": 30,
	"startColumn": 115,
	"endLineNumber": 30,
	"endColumn": 115
},{
	"resource": "/c:/Users/Andrew/Github projects/obsidian-smart-typography/main.js",
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "W049",
	"severity": 4,
	"message": "Unexpected escaped character '<' in regular expression. (W049)",
	"source": "jshint",
	"startLineNumber": 92,
	"startColumn": 18,
	"endLineNumber": 92,
	"endColumn": 18
},{
	"resource": "/c:/Users/Andrew/Github projects/obsidian-smart-typography/main.js",
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "W117",
	"severity": 4,
	"message": "'setTimeout' is not defined. (W117)",
	"source": "jshint",
	"startLineNumber": 125,
	"startColumn": 13,
	"endLineNumber": 125,
	"endColumn": 13
},{
	"resource": "/c:/Users/Andrew/Github projects/obsidian-smart-typography/main.js",
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "W049",
	"severity": 4,
	"message": "Unexpected escaped character '<' in regular expression. (W049)",
	"source": "jshint",
	"startLineNumber": 141,
	"startColumn": 18,
	"endLineNumber": 141,
	"endColumn": 18
},{
	"resource": "/c:/Users/Andrew/Github projects/obsidian-smart-typography/main.js",
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "W117",
	"severity": 4,
	"message": "'setTimeout' is not defined. (W117)",
	"source": "jshint",
	"startLineNumber": 174,
	"startColumn": 13,
	"endLineNumber": 174,
	"endColumn": 13
},{
	"resource": "/c:/Users/Andrew/Github projects/obsidian-smart-typography/main.js",
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "W117",
	"severity": 4,
	"message": "'module' is not defined. (W117)",
	"source": "jshint",
	"startLineNumber": 727,
	"startColumn": 1,
	"endLineNumber": 727,
	"endColumn": 1
}]
```