### PR TITLE
implementation of implication arrows (without IIF)

### DIFF
--- a/inputRules.ts
+++ b/inputRules.ts
@@ -121,6 +121,22 @@ export const arrowRules: InputRule[] = [
   },
 ];
 
+// Implication arrows
+export const implicationArrowRules: InputRule[] = [
+  {
+    trigger: "=",
+    from: "<=",
+    to: (settings) => settings.leftImplicationArrow,
+    contextMatch: /<$/,
+  },
+  {
+    trigger: ">",
+    from: "=>",
+    to: (settings) => settings.rightImplicationArrow,
+    contextMatch: /=$/,
+  },
+];
+ 
 // Guillemet
 export const guillemetRules: InputRule[] = [
   {

--- a/legacyInputRules.ts
+++ b/legacyInputRules.ts
@@ -202,6 +202,21 @@ export const rightArrow: LegacyInputRule = {
   },
 };
 
+export const rightImplicationArrow: LegacyInputRule = {
+  matchTrigger: ">",
+  matchRegExp: /=>$/,
+  performUpdate: (instance, delta, settings) => {
+    delta.update({ line: delta.from.line, ch: delta.from.ch - 1 }, delta.to, [
+      settings.rightArrow,
+    ]);
+  },
+  performRevert: (instance, delta, settings) => {
+    if (instance.getRange(delta.from, delta.to) === settings.rightImplicationArrow) {
+      delta.update(delta.from, delta.to, ["=>"]);
+    }
+  },
+};
+
 export const leftArrow: LegacyInputRule = {
   matchTrigger: "-",
   matchRegExp: /<-$/,
@@ -213,6 +228,21 @@ export const leftArrow: LegacyInputRule = {
   performRevert: (instance, delta, settings) => {
     if (instance.getRange(delta.from, delta.to) === settings.leftArrow) {
       delta.update(delta.from, delta.to, ["<-"]);
+    }
+  },
+};
+
+export const leftImplicationArrow: LegacyInputRule = {
+  matchTrigger: "=",
+  matchRegExp: /<=$/,
+  performUpdate: (instance, delta, settings) => {
+    delta.update({ line: delta.from.line, ch: delta.from.ch - 1 }, delta.to, [
+      settings.leftArrow,
+    ]);
+  },
+  performRevert: (instance, delta, settings) => {
+    if (instance.getRange(delta.from, delta.to) === settings.leftImplicationArrow) {
+      delta.update(delta.from, delta.to, ["<="]);
     }
   },
 };
@@ -310,4 +340,5 @@ export const legacyComparisonRules = [
   notEqualTo,
 ];
 export const legacyArrowRules = [leftArrow, rightArrow];
+export const legacyImplicationArrowRules = [leftImplicationArrow, rightImplicationArrow];
 export const legacyGuillemetRules = [leftGuillemet, rightGuillemet];

--- a/main.ts
+++ b/main.ts
@@ -10,6 +10,7 @@ import {
 import {
   InputRule,
   arrowRules,
+  implicationArrowRules,
   comparisonRules,
   dashRules,
   dashRulesSansEnDash,
@@ -21,6 +22,7 @@ import {
 import {
   LegacyInputRule,
   legacyArrowRules,
+  legacyImplicationArrowRules,
   legacyComparisonRules,
   legacyDashRules,
   legacyEllipsisRules,
@@ -37,6 +39,7 @@ const DEFAULT_SETTINGS: SmartTypographySettings = {
   emDash: true,
   ellipsis: true,
   arrows: true,
+  implicationArrows: true,
   comparisons: true,
   fractions: false,
   guillemets: false,
@@ -53,6 +56,9 @@ const DEFAULT_SETTINGS: SmartTypographySettings = {
 
   leftArrow: "←",
   rightArrow: "→",
+
+  leftImplicationArrow: "⇐",
+  rightImplicationArrow: "⇒",
 };
 
 export default class SmartTypography extends Plugin {
@@ -89,6 +95,11 @@ export default class SmartTypography extends Plugin {
     }
 
     if (this.settings.arrows) {
+      this.inputRules.push(...implicationArrowRules);
+      this.legacyInputRules.push(...legacyImplicationArrowRules);
+    }
+
+    if (this.settings.implicationArrows) {
       this.inputRules.push(...arrowRules);
       this.legacyInputRules.push(...legacyArrowRules);
     }
@@ -580,6 +591,44 @@ class SmartTypographySettingTab extends PluginSettingTab {
               return;
             }
             this.plugin.settings.rightArrow = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
+    new Setting(containerEl)
+      .setName("Implication arrows")
+      .setDesc("<= |=> will be converted to ⇐ | ⇒")
+      .addToggle((toggle) => {
+        toggle.setValue(this.plugin.settings.implicationArrows).onChange(async (value) => {
+          this.plugin.settings.implicationArrows = value;
+          await this.plugin.saveSettings();
+        });
+      });
+
+    new Setting(containerEl).setName("Left implication arrow character").addText((text) => {
+      text.setValue(this.plugin.settings.leftImplicationArrow).onChange(async (value) => {
+        if (!value) return;
+        if (value.length > 1) {
+          text.setValue(value[0]);
+          return;
+        }
+        this.plugin.settings.leftImplicationArrow = value;
+        await this.plugin.saveSettings();
+      });
+    });
+
+    new Setting(containerEl)
+      .setName("Right implication arrow character")
+      .addText((text) => {
+        text
+          .setValue(this.plugin.settings.rightImplicationArrow)
+          .onChange(async (value) => {
+            if (!value) return;
+            if (value.length > 1) {
+              text.setValue(value[0]);
+              return;
+            }
+            this.plugin.settings.rightImplicationArrow = value;
             await this.plugin.saveSettings();
           });
       });

--- a/types.ts
+++ b/types.ts
@@ -3,6 +3,7 @@ export interface SmartTypographySettings {
   emDash: boolean;
   ellipsis: boolean;
   arrows: boolean;
+  implicationArrows: boolean;
   guillemets: boolean;
   comparisons: boolean;
   fractions: boolean;
@@ -16,4 +17,6 @@ export interface SmartTypographySettings {
   closeGuillemet: string;
   leftArrow: string;
   rightArrow: string;
+  leftImplicationArrow: string;
+  rightImplicationArrow: string;
 }


### PR DESCRIPTION
Implementation of implication arrows (`<=`, `=>`)

IIF ("if and only if", `⟺`) is too tricky to implement with my current understanding of the replacement engine, even with `⇐` hardcoded to rule

https://github.com/mgmeyers/obsidian-smart-typography/issues/32