### PR TITLE
Add superscripts and subscripts (with toggles)

### DIFF
--- a/inputRules.ts
+++ b/inputRules.ts
@@ -270,3 +270,179 @@ export const fractionRules: InputRule[] = [
     contextMatch: /(?:^|\s)1\/1$/,
   },
 ];
+
+// Superscripts
+export const superscriptRules: InputRule[] = [
+  {
+    trigger: "0",
+    from: "^0",
+    to: "⁰",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "1",
+    from: "^1",
+    to: "¹",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "2",
+    from: "^2",
+    to: "²",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "3",
+    from: "^3",
+    to: "³",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "4",
+    from: "^4",
+    to: "⁴",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "5",
+    from: "^5",
+    to: "⁵",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "6",
+    from: "^6",
+    to: "⁶",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "7",
+    from: "^7",
+    to: "⁷",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "8",
+    from: "^8",
+    to: "⁸",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "9",
+    from: "^9",
+    to: "⁹",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "+",
+    from: "^+",
+    to: "⁺",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "-",
+    from: "^-",
+    to: "⁻",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "=",
+    from: "^=",
+    to: "⁼",
+    contextMatch: /\^$/,
+  },
+  {
+    trigger: "n",
+    from: "^n",
+    to: "ⁿ",
+    contextMatch: /\^$/,
+  },
+];
+
+// Subscripts
+export const subscriptRules: InputRule[] = [
+  {
+    trigger: "0",
+    from: "_0",
+    to: "₀",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "1",
+    from: "_1",
+    to: "₁",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "2",
+    from: "_2",
+    to: "₂",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "3",
+    from: "_3",
+    to: "₃",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "4",
+    from: "_4",
+    to: "₄",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "5",
+    from: "_5",
+    to: "₅",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "6",
+    from: "_6",
+    to: "₆",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "7",
+    from: "_7",
+    to: "₇",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "8",
+    from: "_8",
+    to: "₈",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "9",
+    from: "_9",
+    to: "₉",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "+",
+    from: "_+",
+    to: "₊",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "-",
+    from: "_-",
+    to: "₋",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "=",
+    from: "_=",
+    to: "₌",
+    contextMatch: /_$/,
+  },
+  {
+    trigger: "n",
+    from: "_n",
+    to: "ₙ",
+    contextMatch: /_$/,
+  },
+];

--- a/main.ts
+++ b/main.ts
@@ -17,6 +17,8 @@ import {
   fractionRules,
   guillemetRules,
   smartQuoteRules,
+  superscriptRules,
+  subscriptRules,
 } from "inputRules";
 import {
   LegacyInputRule,
@@ -41,6 +43,8 @@ const DEFAULT_SETTINGS: SmartTypographySettings = {
   fractions: false,
   guillemets: false,
   skipEnDash: false,
+  superscripts: false,
+  subscripts: false,
 
   openSingle: "‘",
   closeSingle: "’",
@@ -105,6 +109,14 @@ export default class SmartTypography extends Plugin {
 
     if (this.settings.fractions) {
       this.inputRules.push(...fractionRules);
+    }
+
+    if (this.settings.superscripts) {
+      this.inputRules.push(...superscriptRules);
+    }
+
+    if (this.settings.subscripts) {
+      this.inputRules.push(...subscriptRules);
     }
 
     this.inputRules.forEach((rule) => {
@@ -609,6 +621,34 @@ class SmartTypographySettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           });
       });
+
+      new Setting(containerEl)
+        .setName("Superscripts")
+        .setDesc(
+          "R^2 will be converted to R². Supports UTF-8 superscripts for numbers 0-9, +, -, =, and 'n'."
+        )
+        .addToggle((toggle) => {
+          toggle
+            .setValue(this.plugin.settings.superscripts)
+            .onChange(async (value) => {
+              this.plugin.settings.superscripts = value;
+              await this.plugin.saveSettings();
+            });
+        });
+
+        new Setting(containerEl)
+          .setName("Subscripts")
+          .setDesc(
+            "H_2 will be converted to H₂. Supported UTF-8 subscripts for numbers 0-9, +, -, =, and 'n'."
+          )
+          .addToggle((toggle) => {
+            toggle
+              .setValue(this.plugin.settings.subscripts)
+              .onChange(async (value) => {
+                this.plugin.settings.subscripts = value;
+                await this.plugin.saveSettings();
+              });
+          });
   }
 }
 

--- a/types.ts
+++ b/types.ts
@@ -6,6 +6,8 @@ export interface SmartTypographySettings {
   guillemets: boolean;
   comparisons: boolean;
   fractions: boolean;
+  superscripts: boolean;
+  subscripts: boolean;
   skipEnDash: boolean;
 
   openSingle: string;


### PR DESCRIPTION
## Overview

Implements automatic replacement of numbers, operators, and the letter 'n' with their respective superscript and subscript characters triggered by the standard caret- and underscore-notation:
- `^2` becomes `²`
- `_3` becomes `₃`

## Considerations

Although there are technically sup/sub variants for many capital and lowercase letters (including Greeks, parentheses, IPA, etc.), they have been omitted from the commit because
1. support across different fonts is already spotty,
2. they don't look very good in Obsidian,
3. anything beyond this scope is better suited to more robust typesetting anyway.

The purpose of this feature is mostly just for quickly jotting down the most common script variants, not offering parallel functionality to serious text renderers (like the existing ability to type fractions).

Since I only use Obsidian for taking notes, that's no big deal for me.

## Comparison
Keypresses:
![image](https://github.com/user-attachments/assets/56f225df-34d0-4a06-9633-eb1cee67ad85)
Render:
![image](https://github.com/user-attachments/assets/bd3363ef-1f0b-48b6-b122-0ad432a824bf)


## Supported glyphs
| Base | Superscript | Subscript |
|------|-------------|-----------|
| 0    | ⁰           | ₀         |
| 1    | ¹           | ₁         |
| 2    | ²           | ₂         |
| 3    | ³           | ₃         |
| 4    | ⁴           | ₄         |
| 5    | ⁵           | ₅         |
| 6    | ⁶           | ₆         |
| 7    | ⁷           | ₇         |
| 8    | ⁸           | ₈         |
| 9    | ⁹           | ₉         |
| +    | ⁺           | ₊         |
| -    | ⁻           | ₋         |
| =    | ⁼           | ₌         |
| n    | ⁿ           | ₙ         |
